### PR TITLE
Fix getSimilarTracks and SimilarTracksResponse (mm -> m)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "yandex.music"
   ],
   "dependencies": {
-    "axios": "^1.6.2",
+    "axios": "^1.7.7",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@types/node": "^14.14.16",
-    "@types/xml2js": "^0.4.7",
-    "prettier": "2.2.1",
-    "typescript": "^4.1.3"
+    "@types/node": "^22.5.4",
+    "@types/xml2js": "^0.4.14",
+    "prettier": "3.3.3",
+    "typescript": "^5.6.2"
   },
   "scripts": {
     "build": "tsc",

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -700,9 +700,9 @@ export type PodcastsResponse = {
   podcasts: Array<number>;
 };
 
-export type SimmilarTracksResponse = {
+export type SimilarTracksResponse = {
   track: Track;
-  simmilarTracks: Array<Track>;
+  similarTracks: Array<Track>;
 };
 
 type QueueContext = {

--- a/src/YMApi.ts
+++ b/src/YMApi.ts
@@ -42,7 +42,7 @@ import {
   NewReleasesResponse,
   NewPlaylistsResponse,
   PodcastsResponse,
-  SimmilarTracksResponse,
+  SimilarTracksResponse,
   StationTracksResponse,
   StationInfoResponse,
   AllStationsListResponse,
@@ -561,12 +561,12 @@ export default class YMApi {
    * GET: /tracks/{track_id}/similar
    * @returns simmilar tracks
    */
-  getSimmilarTracks(trackId: TrackId): Promise<SimmilarTracksResponse> {
+  getSimilarTracks(trackId: TrackId): Promise<SimilarTracksResponse> {
     const request = apiRequest()
       .setPath(`/tracks/${trackId}/similar`)
       .addHeaders(this.getAuthHeader());
 
-    return this.httpClient.get(request) as Promise<SimmilarTracksResponse>;
+    return this.httpClient.get(request) as Promise<SimilarTracksResponse>;
   }
 
   /**


### PR DESCRIPTION
Update
axios: 1.6.2 -> 1.7.7
@types/node: 14.14.16 -> 22.5.4
@types/xml2js: 0.4.7 -> 0.4.14
prettier: 2.2.1 -> 3.3.3
typescript 4.1.3 -> 5.6.2